### PR TITLE
feat: add IAS for 2025

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
 	<form id="form_gross_wage" onsubmit="onSubmit(event);">
     <label>Year</label>
 		<select name="input_year_ias" class="form-select">
+		<option value=522.50 >2025</option>
 		<option value=509.26 >2024</option>
   		<option value=480.43 >2023</option>
   		<option value=443.20 >2022</option>  		


### PR DESCRIPTION
This pull request includes an update to the `index.html` file to add a new option for the year 2025 in the year selection dropdown.

Changes to the year selection dropdown:

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R29): Added a new option for the year 2025 with a value of 522.50 in the year selection dropdown.

Reference: https://www2.gov.pt/en/noticias/salarios-e-pensoes-novas-tabelas-de-retencao-na-fonte-para-2025